### PR TITLE
Fix docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ KùzuDB graph database.
 
 For details about these libraries, see:
 
-  - RDF support in KùzuDB <https://kuzudb.com/docusaurus/rdf-graphs/>
+  - RDF support in KùzuDB <https://docs.kuzudb.com/rdf-graphs/>
   - RDFlib <https://rdflib.readthedocs.io/>
   - pySHACL <https://github.com/RDFLib/pySHACL>
   - SHACL <https://www.w3.org/TR/shacl/>


### PR DESCRIPTION
Kùzu recently updated the subdomain in which the docs sit. This PR fixes the links to the RDF docs page.