### PR TITLE
Update constraint to be slightly more realistic

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,11 @@ These steps use the [`uv` package manager](https://github.com/astral-sh/uv) to c
 git clone https://github.com/DerwenAI/kuzu-rdflib.git
 cd kuzu-rdflib
 
-# Use uv to create a virtual environment
-uv venv
-source .venv/bin/activate
+python3 -m venv venv
+source venv/bin/activate
 
-uv pip install -U wheel setuptools
-uv pip install -r requirements.txt
+python3 -m pip install -U pip wheel setuptools
+python3 -m pip install -r requirements.txt
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ For details about these libraries, see:
 git clone https://github.com/DerwenAI/kuzu-rdflib.git
 cd kuzu-rdflib
 
-python3 -m venv venv
-source venv/bin/activate
+# Use uv to create a virtual environment
+uv venv
+source .venv/bin/activate
 
-python3 -m pip install -U pip wheel setuptools
-python3 -m pip install -r requirements.txt
+uv pip install -U wheel setuptools
+uv pip install -r requirements.txt
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ For details about these libraries, see:
 
 ## Set up
 
-These steps use the [`uv` package manager](https://github.com/astral-sh/uv) to create a virtual environment.
-
 ```bash
 git clone https://github.com/DerwenAI/kuzu-rdflib.git
 cd kuzu-rdflib

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ For details about these libraries, see:
 
 ## Set up
 
+These steps use the [`uv` package manager](https://github.com/astral-sh/uv) to create a virtual environment.
+
 ```bash
 git clone https://github.com/DerwenAI/kuzu-rdflib.git
 cd kuzu-rdflib

--- a/demo.py
+++ b/demo.py
@@ -63,8 +63,8 @@ kz:PersonShape
     a sh:NodeShape ;
     sh:targetClass kz:student ;
     sh:property [
-        sh:path kz:name ;
-        sh:minLength 5
+        sh:path kz:age ;
+        sh:datatype xsd:integer
     ] .
 """
 

--- a/uni.ttl
+++ b/uni.ttl
@@ -9,7 +9,7 @@ kz:Waterloo a kz:City ;
 kz:Adam a kz:student ;
     kz:livesIn kz:Waterloo ;
     kz:name "Adam" ;
-    kz:age  30 .
+    kz:age 30.0 .
 
 kz:student rdfs:subClassOf kz:person .
 


### PR DESCRIPTION
To address Semih's comment that the earlier constraint of a name's string length being at least 5 is too artificial, I've updated the example to check that that the `age` property is an integer. This is a bit more realistic, as sometimes numeric fields in real-world data can mix up integers and floats, so we'd want to check that the age is provided as `30` rather than `30.0`. The example now fails the constraint with the following message, which I think is quite readable to a new user.

```turtle
Validation Report
Conforms: False
Results (1):
Constraint Violation in DatatypeConstraintComponent (http://www.w3.org/ns/shacl#DatatypeConstraintComponent):
        Severity: sh:Violation
        Source Shape: [ sh:datatype xsd:integer ; sh:path kz:age ]
        Focus Node: <http://kuzu.io/rdf-ex#Adam>
        Value Node: Literal("30.0", datatype=xsd:double)
        Result Path: kz:age
        Message: Value is not Literal with datatype xsd:integer
```