### PR TITLE
Fix #7 by pinning dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ python3 demo.py
 
 > [!NOTE]
 > Why we need to pin the dependency for Kùzu specifically:
-> - Starting from Kùzu v0.7.0, we will temporarily stop supporting RDFGraphs as the current implementation is not very scalable and maintainable. The Kùzu core team is thinking deeply about this, and we have plans to re-implement RDFGraphs in Kùzu as an extension so that we don't have a bloated binary for the database.
-> - Users who want to experiment with pyshacl and rdflib using Kùzu can still do so using the pinned versions of packages specified in this repo.
+> - Starting from Kùzu v0.7.0, we will temporarily stop supporting RDFGraphs as the current implementation is not very scalable and maintainable. The Kùzu core team has made plans to re-implement RDFGraphs in Kùzu as an extension so that we don't have a bloated binary for the database. Stay tuned!
+> - Users who want to experiment with `pyshacl` and `rdflib` using Kùzu can still do so using the pinned versions of packages specified in this repo.
 >
 > Please join the Kùzu [Discord](https://kuzudb.com/chat) if you want to discuss more on RDF graphs and Kùzu!

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ python3 demo.py
 
 > [!NOTE]
 > Why we need to pin the dependency for Kùzu specifically:
-> - Starting from the next release of Kùzu (0.7.0), we will temporarily stop supporting RDFGraphs as the current implementation is not very scalable and maintainable. The Kùzu core team is thinking deeply about this, and we have plans to re-implement RDFGraphs in Kùzu as an extension so that we don't have a bloated binary for the database.
+> - Starting from Kùzu v0.7.0, we will temporarily stop supporting RDFGraphs as the current implementation is not very scalable and maintainable. The Kùzu core team is thinking deeply about this, and we have plans to re-implement RDFGraphs in Kùzu as an extension so that we don't have a bloated binary for the database.
 > - Users who want to experiment with pyshacl and rdflib using Kùzu can still do so using the pinned versions of packages specified in this repo.
+>
 > Please join the Kùzu [Discord](https://kuzudb.com/chat) if you want to discuss more on RDF graphs and Kùzu!

--- a/README.md
+++ b/README.md
@@ -41,3 +41,9 @@ and SHACL validation:
 ```bash
 python3 demo.py
 ```
+
+> [!NOTE]
+> Why we need to pin the dependency for Kùzu specifically:
+> - Starting from the next release of Kùzu (0.7.0), we will temporarily stop supporting RDFGraphs as the current implementation is not very scalable and maintainable. The Kùzu core team is thinking deeply about this, and we have plans to re-implement RDFGraphs in Kùzu as an extension so that we don't have a bloated binary for the database.
+> - Users who want to experiment with pyshacl and rdflib using Kùzu can still do so using the pinned versions of packages specified in this repo.
+> Please join the Kùzu [Discord](https://kuzudb.com/chat) if you want to discuss more on RDF graphs and Kùzu!

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-chocolate >= 0.0.2
-icecream >= 2.1
-kuzu >= 0.3
-pandas >= 2.2
-pyshacl >= 0.25
-rdflib >= 7.0
+chocolate == 0.0.2
+icecream == 2.1.3
+kuzu == 0.6.1
+pandas == 2.2.3
+pyshacl == 0.29.0
+rdflib == 7.1.1


### PR DESCRIPTION
Fixes #7. This PR pins the dependencies to exact versions rather than letting the dependency resolver figure it out (only setting the lower bounds on the dependency versions might not be deterministic enough cross-platform).

Why we need to pin the dependency for Kùzu specifically:
- Starting from the next release of Kùzu (0.7.0), we will temporarily stop supporting RDFGraphs as the current implementation is not very maintainable. The Kùzu core team is thinking deeply about this, and we have plans to re-implement RDFGraphs in Kùzu as an extension so that we don't have a bloated binary for the database.
- Users who want to experiment with `pyshacl` and `rdflib` using Kùzu can still do so using the pinned versions of packages specified in this repo.

For anybody that reads this in the future, please join the Kùzu [Discord](https://kuzudb.com/chat) if you want to discuss more on RDF graphs and Kùzu!